### PR TITLE
Use error instead of nil in (condition-case)

### DIFF
--- a/calfw.el
+++ b/calfw.el
@@ -1004,14 +1004,14 @@ VIEW is a symbol of the view type."
   (cl-loop for f in (cfw:component-click-hooks component)
         do (condition-case err
                (funcall f)
-             (nil (message "Calfw: Click / Hook error %S [%s]" f err)))))
+             (error (message "Calfw: Click / Hook error %S [%s]" f err)))))
 
 (defun cfw:cp-fire-update-hooks (component)
   "[internal] Call update hook functions of the component with no arguments."
   (cl-loop for f in (cfw:component-update-hooks component)
         do (condition-case err
                (funcall f)
-             (nil (message "Calfw: Update / Hook error %S [%s]" f err)))))
+             (error (message "Calfw: Update / Hook error %S [%s]" f err)))))
 
 
 


### PR DESCRIPTION
This fixes this error on Emacs 30:

```bash
Compiling file /Users/dima/Developer/dotfiles/emacs/scripts/calfw-fork/calfw.el at Sat Jul  1 15:22:34 2023
Entering directory ‘/Users/dima/Developer/dotfiles/emacs/scripts/calfw-fork/’

Compiling internal form(s) at Sat Jul  1 15:22:34 2023
Warning (bytecomp): ‘nil’ is not a condition name (in condition-case)
```