### PR TITLE
require `cl-lib` to solve issues with nativecomp

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -38,6 +38,7 @@
 (require 'org-agenda)
 (require 'org-element)
 (require 'org-capture)
+(require 'cl-lib)
 (require 'google-maps nil t)
 
 (defgroup cfw-org nil


### PR DESCRIPTION
this seems to solve the issue with `(void-variable for)` &c. that occur otherwise with the natively-compiled version